### PR TITLE
Húsnúmer in grammar

### DIFF
--- a/src/reynir/Reynir.grammar
+++ b/src/reynir/Reynir.grammar
@@ -3221,11 +3221,13 @@ $score(-12) LangtSérnafnNf
 $score(+6) LangtSérnafn
 $score(+10) LangtSérnafn/fall
 
-# Heimilisfang (götuheiti + tala)
+# Heimilisfang (götuheiti + húsnúmer)
 
 NlStak_et_p3/fall/kyn → Heimilisfang/fall/kyn
 
-Heimilisfang/fall/kyn → gata/fall/kyn tala # !!! TODO: húsnúmer (7a, 13C)
+Heimilisfang/fall/kyn → gata/fall/kyn Húsnúmer
+
+Húsnúmer → tala | talameðbókstaf
 
 $score(+4) Heimilisfang/fall/kyn
 

--- a/src/reynir/binparser.py
+++ b/src/reynir/binparser.py
@@ -810,6 +810,9 @@ class BIN_Token(Token):
                     return False
         return True
 
+    def matches_NUMWLETTER(self, terminal):
+        return terminal.startswith("talameðbókstaf")
+
     def matches_AMOUNT(self, terminal):
         """ An amount token matches a noun terminal """
         if not terminal.startswith("no"):
@@ -1236,6 +1239,7 @@ class BIN_Token(Token):
         TOK.PUNCTUATION: matches_PUNCTUATION,
         TOK.CURRENCY: matches_CURRENCY,
         TOK.AMOUNT: matches_AMOUNT,
+        TOK.NUMWLETTER: matches_NUMWLETTER,
         TOK.NUMBER: matches_NUMBER,
         TOK.PERCENT: matches_PERCENT,
         TOK.ORDINAL: matches_ORDINAL,

--- a/src/reynir/bintokenizer.py
+++ b/src/reynir/bintokenizer.py
@@ -744,9 +744,7 @@ def parse_phrases_2(token_stream, token_ctor):
             def unknown_surname(tok):
                 """ Check for unknown (non-Icelandic) surnames """
                 # Accept (most) upper case words as a surnames
-                if tok.kind != TOK.WORD:
-                    return False
-                if not tok.txt[0].isupper():
+                if tok.kind != TOK.WORD or not tok.txt[0].isupper():
                     # Must start with capital letter
                     return False
                 if has_category(tok, PATRONYM_SET):

--- a/src/reynir/config/BinErrata.conf
+++ b/src/reynir/config/BinErrata.conf
@@ -14,12 +14,13 @@
 
 # Word stem/ordfl/fl to delete when constructing ord.compressed
 
-Gamli 	kk 	ism
-Ísrael	kk	alm
-Vilji	kk	ism
-slæmur 	kk	alm
+Gamli   kk  ism
+Ísrael  kk  alm
+Vilji   kk  ism
+slæmur  kk  alm
 mig     hk  alm
-
+Þuríður     kvk örn 
+Guðfinna    kvk örn
 
 [bin_errata]
 
@@ -62,7 +63,7 @@ Tungusveit kvk örn
 Útmannasveit kvk örn
 Þingeyjarsveit kvk örn
 Þingvallasveit kvk örn
-
+Rangárvallasýsla kvk örn
 
 # Orð merkt sem "göt" en eru ekki í 
 # staðfangaskrá og finnast í örnefnaskrá
@@ -103,6 +104,7 @@ Orustudalur kk örn
 Presthús hk örn
 Pálmalundur kk örn
 Pálshús hk örn
+Reykjarfjörður kk örn
 Saltaberg hk örn
 Selhamar kk örn
 Selhamrar kk örn
@@ -117,6 +119,11 @@ Vatnsleysuströnd kvk örn
 Ytri-Hólmur kk örn
 Álftafjörður kk örn
 Örfirisey kvk örn
+
+
+# Orð merkt sem "örn" en ættu að greinast sem "göt"
+
+Hallarmúli kk göt
 
 
 # Orð sem eru bara til sem "fyr" í BÍN en
@@ -212,6 +219,7 @@ Bláland hk örn
 Blámýrar kvk örn
 Blámýri kvk örn
 Blátún hk göt
+Bláskógabyggð kvk örn
 Blávatn hk örn
 Blönduóshöfn kvk örn
 Blönduóskirkja kvk örn
@@ -1626,4 +1634,9 @@ Volga kvk örn
 Vín kvk örn
 Óðinsvé hk örn
 Rómarborg kvk örn
+
+# Mannsnöfn sem eru bara til í öðrum flokki í BÍN
+
+Sæbjörg kvk ism     # Bara til sem 'fyr' í BÍN
+Jesús kk erm        # Til sem 'alm' í BÍN
 

--- a/src/reynir/config/BinErrata.conf
+++ b/src/reynir/config/BinErrata.conf
@@ -21,6 +21,7 @@ slæmur  kk  alm
 mig     hk  alm
 Þuríður     kvk örn 
 Guðfinna    kvk örn
+Landmannalaugar kvk örn # Orðmyndir eru allar "LandmannaLaugar"
 
 [bin_errata]
 

--- a/src/reynir/config/Phrases.conf
+++ b/src/reynir/config/Phrases.conf
@@ -185,6 +185,7 @@ meaning = hk ætt -
 "Andersen"
 "Bartoszek"
 "Blöndal"
+"Breiðfjörð"
 "Briem"
 "Brink"
 "Diego"
@@ -198,20 +199,26 @@ meaning = hk ætt -
 "Hjaltested"
 "Hjaltalín"
 "Huijbens"
+"Húnfjörð"
+"Ísberg"
 "Jensen"
 "Johnsen"
+"Jörgensen"
+"Knudsen"
 "Kvaran"
 "Morthens"
 "Mosty"
 "Möller"
 "Nelson"
 "Nielsen"
+"Nordal"
 "Norðdahl"
 "Olsen"
 "Ottesen"
 "Petersen"
 "Proppé"
 "Scheving"
+"Schram"
 "Thomsen"
 "Thorarensen"
 "Thoroddsen"
@@ -233,8 +240,11 @@ meaning = hk ætt EFET
 "Hansens"
 # "Hagalíns" er í BÍN
 "Hjaltalíns"
+"Ísbergs"
 "Jensens"
 "Johnsens"
+"Jörgensens"
+"Knudsens"
 "Kvarans"
 "Mogensens"
 "Mostys"
@@ -247,6 +257,7 @@ meaning = hk ætt EFET
 "Ottesens"
 "Petersens"
 "Proppés"
+"Schrams"
 "Thomsens"
 "Thorarensens"
 "Thoroddsens"
@@ -308,11 +319,11 @@ meaning = entity fjölm -
 "Eurosport"
 "Forbes"
 "Guardian"
+"The Guardian"
 "Metropolitan"
 "Politiken"
 "Reykjavik Media"
 "Süddeutsche Zeitung"
-"The Guardian"
 
 meaning = entity fótb -
 "Ajax"
@@ -394,7 +405,6 @@ meaning = entity erl -
 "Brexit"
 "Daesh"
 "Eurovision"
-"Exeter"
 "Hamas"
 "Hezbollah"
 "iPhone"
@@ -463,10 +473,8 @@ meaning = entity farartæki -
 meaning = kk örn -
 "Sigló" # Siglufjörður
 
-
-meaning = entity alm EFET
+meaning = entity örn EFET
 "Tortólu"
-"Ekvadors"
 
 meaning = entity lönd -
 "Ghana"
@@ -481,15 +489,19 @@ meaning = entity lönd -
 "Austur-Kongó"
 "Vestur-Kongó"
 "Lúxembúrg"
+"Búrkína Fasó"
+"Bahrain"
 
 meaning = entity lönd EFET
 "Jemens"
 "Gabons"
+"Ekvadors"
 
 # Borgir, ríki í BNA
 meaning = entity borg -
 "Aalbæk"
 "Aberdeen"
+"Adelaide"
 "Akkra"
 "Abu Dhabi"
 "Alabama"
@@ -581,6 +593,7 @@ meaning = entity borg -
 "El Paso"
 "Erfurt"
 "Essen"
+"Exeter"
 "Falluja"
 "Fallujah"
 "Fargo"
@@ -666,6 +679,7 @@ meaning = entity borg -
 "Lissabon"
 "Liverpool"
 "Lílongve"
+"Lilongwe"
 "Líma"
 "Ljúblíana"
 "Ljubljana"
@@ -699,6 +713,7 @@ meaning = entity borg -
 "Maryland"
 "Maserú"
 "Massachusetts"
+"Mekka"
 "Melbourne"
 "Memphis"
 "Miami"
@@ -883,6 +898,7 @@ meaning = entity borg EFET
 "Kremlar"
 "Parísar"
 "Þessalóníku"
+"Mekku"
 
 meaning = entity örn -
 "Everest"


### PR DESCRIPTION
NUMWLETTER tokens now recognised in binparser, grammar updated to support NP-ADDR ("Heimilisfang") nonterminal with NUMWLETTER tokens (e.g. '18a').

Also a slew of additions to BinErrata and Phrases.